### PR TITLE
Newline in VERSION file causes HTTP request failure

### DIFF
--- a/lib/swd.rb
+++ b/lib/swd.rb
@@ -10,7 +10,7 @@ require 'attr_optional'
 module SWD
   VERSION = ::File.read(
     ::File.join(::File.dirname(__FILE__), '../VERSION')
-  )
+  ).strip
 
   def self.cache=(cache)
     @@cache = cache


### PR DESCRIPTION
A newline introduced at the end of the VERSION file is causing discovery to fail on our OpenID provider due to malformed headers. SWD adds a user-agent header of "SWD (#{VERSION})" to its requests, so when VERSION contains a newline, we end up getting a "400 Bad Request" response from our server.

The fix here is to strip whitespace from what we read from VERSION.