### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/SWD

### DIFF
--- a/swd.gemspec
+++ b/swd.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'
+  s.metadata["changelog_uri"] = s.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/SWD which makes it quick and easy for someone to check on the changes introduced with a new version.

I chose to link to the '/releases' page since that has more details in it than the CHANGELOG.md in the source code repository.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/